### PR TITLE
Normalize binary operators 'and' 'or' to compile under MSVC

### DIFF
--- a/include/sqlpp11/odbc/connection_config.h
+++ b/include/sqlpp11/odbc/connection_config.h
@@ -48,7 +48,7 @@ namespace sqlpp {
 			: data_source_name(std::move(dsn)), type(t), debug(dbg) {}
 
 			bool operator==(const connection_config& other) const {
-				return (other.data_source_name == data_source_name and other.type == type and
+				return (other.data_source_name == data_source_name && other.type == type &&
 				other.debug == debug);
 			}
 

--- a/src/prepared_statement.cpp
+++ b/src/prepared_statement.cpp
@@ -81,7 +81,7 @@ namespace sqlpp {
 		
 		prepared_statement_t::prepared_statement_t(std::shared_ptr<detail::prepared_statement_handle_t>&& handle)
 		: _handle(std::move(handle)) {
-			if(_handle and _handle->debug) {
+			if(_handle && _handle->debug) {
 				std::cerr << "ODBC debug: Constructing prepared_statement, using handle at " << _handle.get() << std::endl;
 			}
 		}


### PR DESCRIPTION
Another option would be to include <ciso646>, but normalizing the operators on two places will make it consistent in whole project
