### PR TITLE
Unify binary operators 'and' 'or' to compile under MSVC

### DIFF
--- a/include/sqlpp11/odbc/connection_config.h
+++ b/include/sqlpp11/odbc/connection_config.h
@@ -67,10 +67,10 @@ namespace sqlpp {
 		inline bool operator==(const connection_config& a, const connection_config& b)
 		{
 			return
-				a.data_source_name == b.data_source_name and
-				a.username == b.username and
-				a.password == b.password and
-				a.type == b.type and
+				a.data_source_name == b.data_source_name &&
+				a.username == b.username &&
+				a.password == b.password &&
+				a.type == b.type &&
 				a.debug == b.debug;
 		}
 
@@ -94,10 +94,10 @@ namespace sqlpp {
 		inline bool operator==(const driver_connection_config& a, const driver_connection_config& b)
 		{
 			return
-				a.connection == b.connection and
-				a.window == b.window and
-				a.completion == b.completion and
-				a.type == b.type and
+				a.connection == b.connection &&
+				a.window == b.window &&
+				a.completion == b.completion &&
+				a.type == b.type &&
 				a.debug == b.debug;
 		}
 

--- a/src/prepared_statement.cpp
+++ b/src/prepared_statement.cpp
@@ -81,7 +81,7 @@ namespace sqlpp {
 		
 		prepared_statement_t::prepared_statement_t(std::shared_ptr<detail::prepared_statement_handle_t>&& handle)
 		: _handle(std::move(handle)) {
-			if(_handle and _handle->debug) {
+			if(_handle && _handle->debug) {
 				std::cerr << "ODBC debug: Constructing prepared_statement, using handle at " << _handle.get() << std::endl;
 			}
 		}


### PR DESCRIPTION
Another option would be to include ciso646, but normalizing the operators on two places will make it consistent in whole project